### PR TITLE
locale independent amount format

### DIFF
--- a/src/QRPlatba.php
+++ b/src/QRPlatba.php
@@ -153,7 +153,7 @@ class QRPlatba
      */
     public function setAmount($amount)
     {
-        $this->keys['AM'] = sprintf('%.2f', $amount);
+        $this->keys['AM'] = number_format($amount, 2, '.', '');
 
         return $this;
     }


### PR DESCRIPTION
Zdravím, 
ve formátování částky je chybně využito sprintf, které částku naformátuje dle lokalizace nastavené na serveru, pokud je tedy nastavena lokalizace výchozí, vše dopadne v pořádku, pokud však česká, místo tečky jsou desetinná místa oddělena čárkou a částku pak nelze do bankovnictví načíst. 
Upraveno za využití number_format, kde oddělovač přímo volíte a je tak na prostředí nezávislá, viz pull request. 
Děkuji