### PR TITLE
Use custom bcmod implementation if php-bcmod is not installed.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,15 @@
         "php": ">=7.4.0",
         "endroid/qr-code": "^4",
         "jschaedl/iban-validation": "^1.4",
-        "ext-mbstring": "*",
-        "ext-bcmath": "*"
+        "ext-mbstring": "*"
     },
     "autoload": {
         "psr-4": {
             "Defr\\QRPlatba\\": "src/"
-        }
+        },
+        "files": [
+            "src/bcmod.php"
+        ]
     },
     "require-dev": {
         "phpunit/phpunit": "^9",

--- a/src/bcmod.php
+++ b/src/bcmod.php
@@ -1,0 +1,32 @@
+<?php
+
+// Check if bcmod module exists, otherwise use this custom implementation.
+if (false === function_exists('bcmod')) {
+    /**
+     * bcmod - get modulus (substitute for bcmod)
+     * string bcmod ( string left_operand, int modulus )
+     * left_operand can be really big, but be carefull with modulus :(
+     * by Andrius Baranauskas and Laurynas Butkus :) Vilnius, Lithuania.
+     *
+     * @param $x
+     * @param $y
+     *
+     * @return int
+     *
+     * @see https://stackoverflow.com/a/10626609
+     */
+    function bcmod($x, $y)
+    {
+        // how many numbers to take at once? carefull not to exceed (int)
+        $take = 5;
+        $mod = '';
+
+        do {
+            $a = (int)$mod.substr($x, 0, $take);
+            $x = substr($x, $take);
+            $mod = $a % $y;
+        } while (strlen($x));
+
+        return (int)$mod;
+    }
+}


### PR DESCRIPTION
Ahoj, při instalaci na produkci jsem zjistil, že je nutné mít `php-bcmod` nainstalované. V rámci řešení jsem našel náhradu funkce, která se nastaví pokud funkce neexistuje. Takto se zjednoduší použití i na infrastruktuře, kde nelze instalovat další php moduly. 

Díky za knihovnu 👍