### PR TITLE
Fixed wrong return type.

### DIFF
--- a/src/bcmod.php
+++ b/src/bcmod.php
@@ -11,7 +11,7 @@ if (false === function_exists('bcmod')) {
      * @param $x
      * @param $y
      *
-     * @return int
+     * @return string
      *
      * @see https://stackoverflow.com/a/10626609
      */
@@ -27,6 +27,6 @@ if (false === function_exists('bcmod')) {
             $mod = $a % $y;
         } while (strlen($x));
 
-        return (int)$mod;
+        return (string)$mod;
     }
 }


### PR DESCRIPTION
Return type of bcmod function needs to be string, because it can return number greater than PHP_INT_MAX, eg for numbers: bcmod(PHP_INT_MAX . '1', PHP_INT_MAX . '2');

So it should have same return type as original PHP function: https://www.php.net/manual/en/function.bcmod.php