### PR TITLE
Require PHP 8.2+

### DIFF
--- a/.github/workflows/travis.yml
+++ b/.github/workflows/travis.yml
@@ -13,9 +13,9 @@ jobs:
         strategy:
             matrix:
                 php-versions:
-                    - 7.4
-                    - 8.0
-                    - 8.1
+                    - 8.2
+                    - 8.3
+                    - 8.4
         name: PHP ${{ matrix.php-versions }} test
 
         steps:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ QRPlatbu v současné době podporují tyto banky:
 Air Bank, Česká spořitelna, ČSOB, Equa bank, Era, Fio banka, Komerční banka, mBank, Raiffeisenbank, ZUNO.
 
 
-Podporuje PHP 7.4 až 8.1.
+Podporuje PHP 8.2+
 
 ## Instalace pomocí Composeru
 

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
         }
     ],
     "require": {
-        "php": ">=7.4.0",
-        "endroid/qr-code": "^4",
-        "jschaedl/iban-validation": "^1.4",
+        "php": ">=8.2",
+        "endroid/qr-code": "^6.0.3",
+        "jschaedl/iban-validation": "^v2.5.1",
         "ext-mbstring": "*"
     },
     "autoload": {

--- a/src/QRPlatba.php
+++ b/src/QRPlatba.php
@@ -16,12 +16,11 @@ namespace Defr\QRPlatba;
 use DateTime;
 use Endroid\QrCode\Color\Color;
 use Endroid\QrCode\Encoding\Encoding;
-use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelMedium;
-use Endroid\QrCode\Label\Alignment\LabelAlignmentLeft;
+use Endroid\QrCode\ErrorCorrectionLevel;
 use Endroid\QrCode\Label\Font\OpenSans;
 use Endroid\QrCode\Label\Label;
 use Endroid\QrCode\QrCode;
-use Endroid\QrCode\RoundBlockSizeMode\RoundBlockSizeModeEnlarge;
+use Endroid\QrCode\RoundBlockSizeMode;
 use Endroid\QrCode\Writer\PngWriter;
 use Endroid\QrCode\Writer\SvgWriter;
 use Iban\Validation\Iban;
@@ -721,14 +720,16 @@ class QRPlatba
      */
     public function getQRCodeInstance(int $size = 300, int $margin = 10): QrCode
     {
-        return QrCode::create((string) $this)
-            ->setSize($size - ($margin * 2))
-            ->setEncoding(new Encoding('UTF-8'))
-            ->setErrorCorrectionLevel(new ErrorCorrectionLevelMedium())
-            ->setMargin($margin)
-            ->setRoundBlockSizeMode(new RoundBlockSizeModeEnlarge())
-            ->setForegroundColor(new Color(0, 0, 0, 0))
-            ->setBackgroundColor(new Color(255, 255, 255, 0));
+        return new QrCode(
+            data: (string) $this,
+            encoding: new Encoding('UTF-8'),
+            errorCorrectionLevel: ErrorCorrectionLevel::Medium,
+            size: $size,
+            margin: $margin,
+            roundBlockSizeMode: RoundBlockSizeMode::Margin,
+            foregroundColor: new Color(0, 0, 0),
+            backgroundColor: new Color(255, 255, 255)
+        );
     }
 
     /**
@@ -799,10 +800,11 @@ class QRPlatba
     private function getLabelInstance(): ?Label
     {
         if ($this->label !== null) {
-            return Label::create($this->label)
-                ->setAlignment(new LabelAlignmentLeft())
-                ->setFont(new OpenSans())
-                ->setTextColor(new Color(0, 0, 0, 0));
+            return new Label(
+                text: $this->label,
+                font: new OpenSans(),
+                textColor: new Color(0, 0, 0, 0),
+            );
         }
 
         return null;

--- a/tests/OutputTest.php
+++ b/tests/OutputTest.php
@@ -30,69 +30,69 @@ class OutputTest extends TestCase
         self::assertFileExists($path);
     }
 
-    public function provideFormats()
+    public static function provideFormats()
     {
         return [
             'QR Platba (PNG)' => [
                 'format' => QRPlatba::FORMAT_PNG,
                 'fileName' => 'qr_platba.png',
-                'qrPlatba' => $this->givenQrPlatbaObject(),
+                'qrPlatba' => self::givenQrPlatbaObject(),
             ],
             'QR Platba v EUR (PNG)' => [
                 'format' => QRPlatba::FORMAT_PNG,
                 'fileName' => 'qr_platba_eur.png',
-                'qrPlatba' => $this->givenQrPlatbaObject()->setCurrency('EUR'),
+                'qrPlatba' => self::givenQrPlatbaObject()->setCurrency('EUR'),
             ],
             'QR Platba (SVG)' => [
                 'format' => QRPlatba::FORMAT_SVG,
                 'fileName' => 'qr_platba.svg',
-                'qrPlatba' => $this->givenQrPlatbaObject(),
+                'qrPlatba' => self::givenQrPlatbaObject(),
             ],
             'QR Platba a popisek (PNG)' => [
                 'format' => QRPlatba::FORMAT_PNG,
                 'fileName' => 'qr_platba_popisek.png',
-                'qrPlatba' => $this->givenQrPlatbaObject()->setLabel('QR Platba'),
+                'qrPlatba' => self::givenQrPlatbaObject()->setLabel('QR Platba'),
             ],
             'QR Platba a popisek v EUR (PNG)' => [
                 'format' => QRPlatba::FORMAT_PNG,
                 'fileName' => 'qr_platba_popisek_eur.png',
-                'qrPlatba' => $this->givenQrPlatbaObject()->setCurrency('EUR')->setLabel('QR Platba v EUR'),
+                'qrPlatba' => self::givenQrPlatbaObject()->setCurrency('EUR')->setLabel('QR Platba v EUR'),
             ],
             'QR Platba a popisek (SVG)' => [
                 'format' => QRPlatba::FORMAT_SVG,
                 'fileName' => 'qr_platba_popisek.svg',
-                'qrPlatba' => $this->givenQrPlatbaObject()->setLabel('QR Platba'),
+                'qrPlatba' => self::givenQrPlatbaObject()->setLabel('QR Platba'),
             ],
             'QR Platba+F a popisek (PNG)' => [
                 'format' => QRPlatba::FORMAT_PNG,
                 'fileName' => 'qr_platba_a_faktura_popisek.png',
-                'qrPlatba' => $this->givenQrPlatbaWithInvoiceObject()->setLabel('QR Platba+F'),
+                'qrPlatba' => self::givenQrPlatbaWithInvoiceObject()->setLabel('QR Platba+F'),
             ],
             'QR Platba+F a popisek v EUR (PNG)' => [
                 'format' => QRPlatba::FORMAT_PNG,
                 'fileName' => 'qr_platba_a_faktura_popisek_eur.png',
-                'qrPlatba' => $this->givenQrPlatbaWithInvoiceObject()->setLabel('QR Platba+F')->setCurrency('EUR'),
+                'qrPlatba' => self::givenQrPlatbaWithInvoiceObject()->setLabel('QR Platba+F')->setCurrency('EUR'),
             ],
             'QR Platba+F a popisek (SVG)' => [
                 'format' => QRPlatba::FORMAT_SVG,
                 'fileName' => 'qr_platba_a_faktura_popisek.svg',
-                'qrPlatba' => $this->givenQrPlatbaWithInvoiceObject()->setLabel('QR Platba+F'),
+                'qrPlatba' => self::givenQrPlatbaWithInvoiceObject()->setLabel('QR Platba+F'),
             ],
             'QR Faktura (PNG)' => [
                 'format' => QRPlatba::FORMAT_PNG,
                 'fileName' => 'qr_faktura.png',
-                'qrPlatba' => $this->givenQrPlatbaWithInvoiceObject()->setIsOnlyInvoice(true)->setLabel('QR Faktura (bez platby)'),
+                'qrPlatba' => self::givenQrPlatbaWithInvoiceObject()->setIsOnlyInvoice(true)->setLabel('QR Faktura (bez platby)'),
             ],
         ];
     }
 
-    private function givenQrPlatbaObject(): QRPlatba
+    private static function givenQrPlatbaObject(): QRPlatba
     {
         return QRPlatba::create('1234/0100', 123.45, '1234567890')
             ->setMessage('Předplatné FlixNet');
     }
 
-    private function givenQrPlatbaWithInvoiceObject(): QRPlatba
+    private static function givenQrPlatbaWithInvoiceObject(): QRPlatba
     {
         return QRPlatba::create('1234/0100', 2410.00, '1234567890')
             ->setInvoiceId('FAKT1234')


### PR DESCRIPTION
Hello. I was unable to use the package with the recent PHP versions.

So I have made some changes, updated dependencies and sending the PR.

Changes do not break the library API, but due to the external libraries, PHP 8.2+ is required.

Regards, Jaroslav